### PR TITLE
Fix the issue regarding the error that occurs when the actor exits

### DIFF
--- a/actor/actor.go
+++ b/actor/actor.go
@@ -191,6 +191,7 @@ func (s *actor) exit() {
 	log.SysLog.Infow("actor done", "actorId", s.ID())
 	s.status.Store(stop)
 
+	s.system.CancelAll(s.id)
 	s.system.DispatchEvent(s.id, event.EvDelActor{ActorId: s.id, Publish: s.remote})
 	s.system.actorCache.Delete(s.ID())
 	s.system.waitStop.Done()


### PR DESCRIPTION
"Before exiting, the actor must first unsubscribe from all the listened events; otherwise, the event's origin will be unable to locate the actor, leading to erroneous sending within the cluster.